### PR TITLE
Add composer.lock to export-ignore in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 * text=auto
 
 /tests export-ignore
+/composer.lock export-ignore
 /.editorconfig export-ignore
 /.gitattributes export-ignore
 /.github export-ignore


### PR DESCRIPTION
## Summary
- Adds `/composer.lock export-ignore` to `.gitattributes` so `composer.lock` is excluded from distribution archives
- Matches the convention already used in other ShipMonk PHP libraries (e.g. doctrine-two-phase-migrations, phpstan-rules, etc.)

## Test plan
- [x] Verified the `.gitattributes` file has the correct entry
- [x] CI passes

Co-Authored-By: Claude Code